### PR TITLE
Change padelpy url to http

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "b3clf/padelpy"]
 	path = b3clf/padelpy
-	url = git@github.com:fwmeng88/padelpy.git
+	url = https://github.com/fwmeng88/padelpy.git


### PR DESCRIPTION
Previous URL format generated errors when downloading the package. Error:
```
Submodule 'b3clf/padelpy' (git@github.com:fwmeng88/padelpy.git) registered for path 'b3clf/padelpy'
Cloning into '/home/juansa/modules/B3clf/b3clf/padelpy'...
Permission denied (publickey).
fatal: Could not read from remote repository.
```

 Changing repo's URL to HTTP format seems to avoid this error. See about it in the following issue: https://github.com/cuihenggang/geeps/issues/3